### PR TITLE
Fix run commands

### DIFF
--- a/src/docker/docker-build.sh
+++ b/src/docker/docker-build.sh
@@ -7,4 +7,4 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-/bin/bash =(curl -o - https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/run-local.sh) db
+/bin/bash <(curl -o - https://raw.githubusercontent.com/agile-learning-institute/mentorhub/main/docker-configurations/run-local.sh) db


### PR DESCRIPTION
The prior syntax is specific to zsh and creates a true temporary file. This change allows the commands to run on bash as well.