### PR TITLE
Updated docker-push yaml to push the images to AWS ECR registry

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -7,11 +7,17 @@ on:
       - main
     types:
       - closed
+env:
+  AWS_REGION: us-east-1                              # set this to your preferred AWS region, e.g. us-west-1
+  ECR_REPOSITORY: mentorhub           # set this to your Amazon ECR repository name
+                                          
 jobs:
-  if_merged:
-    if: github.event.pull_request.merged == true
+  Explore-GitHub-Actions:
+  # if_merged:
+  #   if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       -
         name: Checkout
         uses: actions/checkout@v3
@@ -21,19 +27,29 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - 
-        name: Log in to GitHub Container Registry
-        uses: docker/login-action@v1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          file: ./src/docker/Dockerfile 
-          push: true
-          tags: ghcr.io/agile-learning-institute/mentorhub-person-api:latest
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: mentorHub-person-api:DEV-${{ github.sha }}
+        run: |
+          # Build a docker container and
+          # push it to ECR so that it can
+          # be deployed to ECS.
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG . -f /home/runner/work/mentorHub-person-api/mentorHub-person-api/src/docker/Dockerfile
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+  


### PR DESCRIPTION
Updated docker-push yaml to push the images to AWS ECR registry. Now the images will be pushed into mentorHub repo instead of GitHub repo.